### PR TITLE
feat: Add chat interface support for LangGraph Studio

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rg:*)"
+    ],
+    "deny": []
+  }
+}


### PR DESCRIPTION
## Summary
- ✨ Transforms the query-based agent to support LangGraph Studio's chat interface
- 📋 Adds support for pasted documents in chat messages
- 🔄 Maintains full backward compatibility with existing functionality

## Changes Made

### 1. Chat Interface Support
- Extended `MessagesState` to enable chat functionality in LangGraph Studio
- Modified state management to work with message history
- Updated all nodes to extract queries from human messages
- Returns responses as `AIMessage` objects for proper chat formatting

### 2. Document Paste Support
- Created `DocumentPasteHandler` to process pasted documents in messages
- Supports three formats for including documents:
  - Markdown code blocks (` ```language...``` `)
  - Document markers (`<<<DOCUMENT: name>>>...<<<END>>>`)
  - File patterns (`---FILE: name---...---END FILE---`)
- Automatically extracts and includes document content in queries

### 3. State Field Enhancements
- Added `answer` field for intermediate processing
- Preserved all existing fields for retrieval, reasoning, and confidence scoring
- Maintained compatibility with the existing 3-node workflow

## Testing
- ✅ Tested chat interface with simple queries
- ✅ Tested with pasted documents (code, JSON, text)
- ✅ Verified backward compatibility
- ✅ Confirmed all existing features work as expected

## How to Use

### Basic Chat
```python
messages = [HumanMessage(content="What are the coding guidelines for diabetes?")]
result = await graph.ainvoke({"messages": messages}, config)
```

### With Pasted Documents
Users can paste documents directly in their messages:
```
What ICD-10 codes are in this document?

<<<DOCUMENT: guidelines.txt>>>
Diabetes Type 2: E11.9
Hypertension: I10
<<<END>>>
```

## Breaking Changes
None - fully backward compatible

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>